### PR TITLE
Added support for Beetle Coin

### DIFF
--- a/src/js/bitcoinjs-extensions.js
+++ b/src/js/bitcoinjs-extensions.js
@@ -1448,3 +1448,14 @@ bitcoin.networks.bitcoinprivate = {
     scriptHash:0x13AF,
     wif: 128
 }
+
+bitcoin.networks.beetlecoin = {
+  messagePrefix: '\x19Beetlecoin Signed Message:\n',
+  bip32: {
+    public: 0x0488b21e,
+    private: 0x0488ade4
+  },
+  pubKeyHash: 0x1A,
+  scriptHash: 0x55,
+  wif: 0x99,
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -476,6 +476,14 @@
             },
         },
         {
+            name: "Beetlecoin",
+            segwitAvailable: false,
+            onSelect: function() {
+                network = bitcoin.networks.beetlecoin;
+                DOM.bip44coin.val(800);
+            },
+        },
+        {
             name: "Bitcoin",
             onSelect: function() {
                 network = bitcoin.networks.bitcoin;


### PR DESCRIPTION
This particular change allows the Coinomi recovery tool to generate valid beetle addresses. We already have a successful pull request for Beetle Coin to be added to the official slips/44 (though not on the Coinomi forked version). If we can help in any way to get Beetle Coin supported on Coinomi, please indicate how. Any feedback appreciated.